### PR TITLE
Add fallback to recordMode

### DIFF
--- a/MMMTestCase.podspec
+++ b/MMMTestCase.podspec
@@ -6,7 +6,7 @@
 Pod::Spec.new do |s|
 
 	s.name = "MMMTestCase"
-	s.version = "1.13.1"
+	s.version = "1.14.0"
 	s.summary = "Our helpers for FBTestCase and XCTestCase"
 	s.description = s.summary
 	s.homepage = "https://github.com/mediamonks/#{s.name}"

--- a/Sources/MMMTestCaseObjC/MMMTestCase.m
+++ b/Sources/MMMTestCaseObjC/MMMTestCase.m
@@ -478,6 +478,8 @@ static CGFloat _MMMPhaseForDashedPattern(CGFloat lineLength, CGFloat dashLength,
 		return;
 	}
 
+	BOOL recordFallback = [[NSProcessInfo processInfo].environment[@"MMM_FALLBACK_TO_RECORD"] boolValue];
+
 	if (self.recordMode) {
 
 		NSError *error = nil;
@@ -500,6 +502,14 @@ static CGFloat _MMMPhaseForDashedPattern(CGFloat lineLength, CGFloat dashLength,
 			}
 
 			BOOL comparisonSuccess = [self compareSnapshotOfView:view referenceImagesDirectory:dir identifier:identifier tolerance:tolerance error:&error];
+
+			if (!comparisonSuccess && recordFallback) {
+				self.recordMode = YES;
+				[self verifyView:view identifier:identifier suffixes:suffixes tolerance:tolerance];
+				self.recordMode = NO;
+				return;
+			}
+
 			XCTAssertTrue(comparisonSuccess, @"Snapshot comparison failed: %@", error);
 			return;
 		}


### PR DESCRIPTION
This allows setting `MMM_FALLBACK_TO_RECORD=1` to your test scheme, if a snapshot comparison fails, it will record a new one instead of only failing the test.